### PR TITLE
added defaulHeight IBInspectable private property

### DIFF
--- a/Example/Paged Tabs Example/Screens/Main.storyboard
+++ b/Example/Paged Tabs Example/Screens/Main.storyboard
@@ -62,6 +62,11 @@
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="tJO-Jo-WH6" customClass="MSSTabNavigationBar">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="number" keyPath="defaultHeight">
+                                <real key="value" value="48"/>
+                            </userDefinedRuntimeAttribute>
+                        </userDefinedRuntimeAttributes>
                     </navigationBar>
                     <connections>
                         <segue destination="CAa-oM-U9G" kind="relationship" relationship="rootViewController" id="fz1-NB-Rre"/>

--- a/MSSTabbedPageViewController/Components/MSSTabBarView/MSSTabNavigationBar.m
+++ b/MSSTabbedPageViewController/Components/MSSTabBarView/MSSTabNavigationBar.m
@@ -15,6 +15,11 @@ CGFloat const kMSSTabNavigationBarBottomPadding = 4.0f;
 
 @property (nonatomic, weak) MSSTabbedPageViewController *activeTabbedPageViewController;
 
+/**
+ custom default height for the tab bar
+ */
+@property (nonatomic, assign) IBInspectable CGFloat defaultHeight;
+
 @end
 
 @implementation MSSTabNavigationBar
@@ -46,7 +51,10 @@ CGFloat const kMSSTabNavigationBarBottomPadding = 4.0f;
 }
 
 - (CGFloat)heightIncreaseValue {
-    return MSSTabBarViewDefaultHeight + kMSSTabNavigationBarBottomPadding;
+	if (self.defaultHeight != 0.){
+		return self.defaultHeight;
+	}
+	return MSSTabBarViewDefaultHeight + kMSSTabNavigationBarBottomPadding;
 }
 
 - (BOOL)heightIncreaseRequired {


### PR DESCRIPTION
Hi again, 

After the cuestión #8 I send you this pull request.

this request adds a new property named defaultHeigh. this property is private and the user only can use in a storyboard (defaulHeight  is IBInspectable)

Thanks in advance.
