### PR TITLE
Fixed module build error

### DIFF
--- a/MSSTabbedPageViewController/Components/MSSTabBarView/MSSTabBarCollectionViewCell+Private.h
+++ b/MSSTabbedPageViewController/Components/MSSTabBarView/MSSTabBarCollectionViewCell+Private.h
@@ -8,6 +8,7 @@
 
 #import <UIKit/UIKit.h>
 #import "MSSTabStyle.h"
+#import "MSSTabBarCollectionViewCell.h"
 
 @interface MSSTabBarCollectionViewCell ()
 

--- a/MSSTabbedPageViewController/Components/MSSTabBarView/MSSTabNavigationBar/MSSTabNavigationBar+Private.h
+++ b/MSSTabbedPageViewController/Components/MSSTabBarView/MSSTabNavigationBar/MSSTabNavigationBar+Private.h
@@ -6,6 +6,8 @@
 //  Copyright © 2016 Merrick Sapsford. All rights reserved.
 //
 
+#import "MSSTabNavigationBar.h"
+
 @class MSSTabbedPageViewController;
 
 @interface MSSTabNavigationBar ()

--- a/MSSTabbedPageViewController/MSSPageViewController/MSSPageViewController+Private.h
+++ b/MSSTabbedPageViewController/MSSPageViewController/MSSPageViewController+Private.h
@@ -6,6 +6,8 @@
 //  Copyright © 2016 Merrick Sapsford. All rights reserved.
 //
 
+#import "MSSPageViewController.h"
+
 @interface MSSPageViewController () <UIScrollViewDelegate>
 
 /**


### PR DESCRIPTION
When building in a Swift project, the module would fail to build with the error `Could not build Objective-C module 'MSSTabbedPageViewController'` and complain about interface declarations.

Adding imports to a few files fixed these errors and the module builds correctly.
