### PR TITLE
Fixed bundle loading issue when loading from framework

### DIFF
--- a/MSSTabbedPageViewController/Components/MSSTabBarView/MSSTabBarView.m
+++ b/MSSTabbedPageViewController/Components/MSSTabBarView/MSSTabBarView.m
@@ -121,7 +121,7 @@ static MSSTabBarCollectionViewCell *_sizingCell;
         
         // create sizing cell if required
         UINib *cellNib = [UINib nibWithNibName:NSStringFromClass([MSSTabBarCollectionViewCell class])
-                                        bundle:[NSBundle mainBundle]];
+                                        bundle:[NSBundle bundleForClass:[MSSTabBarCollectionViewCell class]]];
         [self.collectionView registerNib:cellNib
               forCellWithReuseIdentifier:MSSTabBarViewCellIdentifier];
         if (!_sizingCell) {


### PR DESCRIPTION
The tab bar view was trying to load directly from the app's main bundle, but when the library is installed as a framework using Cocoapods it creates a secondary bundle just for these resources. By loading the bundle that the class is in, you'll be sure to get the main bundle when the source is included directly, and the Cocoapods bundle when loaded that way.
