### PR TITLE
Fixing a bug where previous tabs overlaps with a normal navigation bar where I dont need tabs

### DIFF
--- a/Source/MSSTabbedPageViewController.m
+++ b/Source/MSSTabbedPageViewController.m
@@ -46,6 +46,7 @@
         tabBarView.dataSource = self;
         tabBarView.delegate = self;
         self.tabBarView = tabBarView;
+        self.tabBarView.hidden = NO;
         
         BOOL isInitialController = (self.navigationController.viewControllers.firstObject == self);
         [navigationBar tabbedPageViewController:self viewWillAppear:animated isInitial:isInitialController];
@@ -64,6 +65,7 @@
         }
         
         // remove the current tab bar
+        self.tabBarView.hidden = YES;
         self.tabBarView = nil;
     }
 }


### PR DESCRIPTION
Showing and hiding the tabBarView manualy in viewWillAppear and viewWillDisappear, because the tabBarView in the MSSTabNavigationBar was never removed or hidden or the rect wasnot made to CGRectZero. Thats why the collectionView inside the MSSTabBarView was showing over the navigation bar in other places, where I dont need tabs. Specially when the NavigationBar is shown or hidden from the code for some pages, this bug definitely happens. Please see the image below.

![image](https://cloud.githubusercontent.com/assets/3830968/23736957/0aaa5350-04ba-11e7-98c8-a2fef9d0a33e.png)
