### PR TITLE
Fixed bug, in iOS 10 TabBar not shown in the navigation bar.

### DIFF
--- a/Source/Utilities/MSSCustomHeightNavigationBar.m
+++ b/Source/Utilities/MSSCustomHeightNavigationBar.m
@@ -10,6 +10,8 @@
 
 CGFloat const MSSStandardBarHeightInvalid = -1.0f;
 
+#define MSS_SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(v)	([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] != NSOrderedAscending)
+
 @interface MSSCustomHeightNavigationBar ()
 
 @property (nonatomic, assign) CGFloat standardBarHeight;
@@ -43,8 +45,7 @@ CGFloat const MSSStandardBarHeightInvalid = -1.0f;
 - (void)layoutSubviews {
     [super layoutSubviews];
     
-    NSArray *classNamesToReposition = @[@"_UINavigationBarBackground"];
-    
+     NSArray *classNamesToReposition = MSS_SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"10.0") ? @[@"_UIBarBackground"] : @[@"_UINavigationBarBackground"];
     for (UIView *view in [self subviews]) {
         
         if ([classNamesToReposition containsObject:NSStringFromClass([view class])]) {


### PR DESCRIPTION
In iOS the Navigation Bar Background key is changed to "_UIBarBackground", thats why the tab bar was not showing in iOS 10. Please see the screenshot. But still there's a bug remaining, the Navigation bar height is not animating in iOS 10, while pushing from "styles" page in the example project.

![screen shot 2017-03-27 at 6 58 52 pm](https://cloud.githubusercontent.com/assets/3830968/25080398/9b28c9b0-2365-11e7-94f8-738e17209134.png)
